### PR TITLE
Support HTTP transport as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,9 @@ VIKUNJA_URL=https://vikunja.example.com
 # Get this from your Vikunja user settings
 VIKUNJA_API_TOKEN=your-api-token-here
 
-# Server mode (optional, defaults to stdio)
+# Server mode (optional, defaults to http)
 # Options: stdio, http
-MCP_MODE=stdio
+MCP_MODE=http
 
 # HTTP server port (only used if MCP_MODE=http)
 MCP_PORT=3000

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { HttpServerTransport } from '@modelcontextprotocol/sdk/server/http.js';
 import dotenv from 'dotenv';
 
 import { AuthManager } from './auth/AuthManager';
@@ -45,12 +46,21 @@ registerTools(server, authManager);
 
 // Start the server
 async function main(): Promise<void> {
-  const transport = new StdioServerTransport();
+  const mode = process.env.MCP_MODE || 'http';
+  let transport;
+
+  if (mode === 'stdio') {
+    transport = new StdioServerTransport();
+  } else {
+    const port = process.env.MCP_PORT ? parseInt(process.env.MCP_PORT, 10) : 3000;
+    transport = new HttpServerTransport({ port });
+  }
+
   await server.connect(transport);
 
   logger.info('Vikunja MCP server started');
   logger.debug('Configuration loaded', {
-    mode: process.env.MCP_MODE,
+    mode,
     debug: process.env.DEBUG,
     hasAuth: !!process.env.VIKUNJA_URL && !!process.env.VIKUNJA_API_TOKEN,
   });


### PR DESCRIPTION
## Summary
- use `MCP_MODE` to choose between `StdioServerTransport` and `HttpServerTransport`
- default to HTTP mode
- update `.env.example` to reflect new default

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b6dcab24832ea49d94871ee160b1